### PR TITLE
adapt redis4net to our logstash setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ data types of fields within the same "type", will cause logstash indexer to chok
 			<remoteAddress value="127.0.0.1" />
 			<remotePort value="6379" />
 			<password value="" />
-      <enableSSL value="false" />          
+			<enableSSL value="false" />
 			<listName value="logstash" />
 			<layout type="redis4net.Layout.LogMessageLayout, redis4net">
 				<param name="IncludeLocationInformation" value="true" />

--- a/README.md
+++ b/README.md
@@ -2,9 +2,14 @@
 redis4net is a log4net appender that formats logs and adds them to redis lists. This is useful when you have another system like logstash which indexes yours 
 logs. The redis lists that you write to can feed into the logstash indexer.
 
-## Installation
+## Installation (Acast)
 
-Working on a nuget package. Meantime, please check out the source code. 
+Nuget package available via gemfury nuget feed (the alternative private repo).
+
+1) Bump to new version in assemblyinfo
+2) Install nuget-cli if you haven't already.
+3) Go to same directory as project file and run nuget pack redis4net.csproj to create new nuget package
+4) Upload the package to gemfury https://gemfury.com/help/upload-packages
 
 ## Configuration
 
@@ -34,6 +39,8 @@ data types of fields within the same "type", will cause logstash indexer to chok
 		<appender name="RedisAppender" type="redis4net.Appender.RedisAppender, redis4net">
 			<remoteAddress value="127.0.0.1" />
 			<remotePort value="6379" />
+			<password value="" />
+      <enableSSL value="false" />          
 			<listName value="logstash" />
 			<layout type="redis4net.Layout.LogMessageLayout, redis4net">
 				<param name="IncludeLocationInformation" value="true" />

--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -5,8 +5,8 @@ using System.Security;
 using System.Runtime.CompilerServices;
 
 [assembly: AssemblyCompany("redis4net")]
-[assembly: AssemblyFileVersion("1.0.1.0")]
-[assembly: AssemblyVersion("1.0.1.0")]	
+[assembly: AssemblyFileVersion("1.0.2.0")]
+[assembly: AssemblyVersion("1.0.2.0")]	
 [assembly: AssemblyCopyright("Copyright ©  2014")]
 [assembly: ComVisible(false)]	
 

--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -5,8 +5,8 @@ using System.Security;
 using System.Runtime.CompilerServices;
 
 [assembly: AssemblyCompany("redis4net")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyVersion("1.0.0.0")]	
+[assembly: AssemblyFileVersion("1.0.1.0")]
+[assembly: AssemblyVersion("1.0.1.0")]	
 [assembly: AssemblyCopyright("Copyright ©  2014")]
 [assembly: ComVisible(false)]	
 

--- a/examples/consoleAppUsage/ConsoleAppUsage.csproj
+++ b/examples/consoleAppUsage/ConsoleAppUsage.csproj
@@ -33,9 +33,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
+    <Reference Include="log4net, Version=2.0.7.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\..\src\packages\log4net.2.0.7\lib\net45-full\log4net.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/examples/consoleAppUsage/packages.config
+++ b/examples/consoleAppUsage/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="log4net" version="2.0.3" targetFramework="net45" />
+  <package id="log4net" version="2.0.7" targetFramework="net452" />
 </packages>

--- a/src/redis4net/Appender/RedisAppender.cs
+++ b/src/redis4net/Appender/RedisAppender.cs
@@ -11,9 +11,9 @@ namespace redis4net.Appender
 		protected ConnectionFactory ConnectionFactory { get; set; }
 		public string RemoteAddress { get; set; }
 		public int RemotePort { get; set; }
-        public string Password { get; set; }
-        public bool EnableSSL { get; set; }
-        public string ListName { get; set; }
+		public string Password { get; set; }
+		public bool EnableSSL { get; set; }
+		public string ListName { get; set; }
 
 		public override void ActivateOptions()
 		{

--- a/src/redis4net/Appender/RedisAppender.cs
+++ b/src/redis4net/Appender/RedisAppender.cs
@@ -11,7 +11,9 @@ namespace redis4net.Appender
 		protected ConnectionFactory ConnectionFactory { get; set; }
 		public string RemoteAddress { get; set; }
 		public int RemotePort { get; set; }
-		public string ListName { get; set; }
+        public string Password { get; set; }
+        public bool EnableSSL { get; set; }
+        public string ListName { get; set; }
 
 		public override void ActivateOptions()
 		{
@@ -23,7 +25,7 @@ namespace redis4net.Appender
 		protected virtual void InitializeConnectionFactory()
 		{
 			var connection = new Connection();
-			ConnectionFactory = new ConnectionFactory(connection, RemoteAddress, RemotePort, 1, ListName);
+			ConnectionFactory = new ConnectionFactory(connection, RemoteAddress, RemotePort, Password, EnableSSL, 1, ListName);
 		}
 
 		protected override void Append(log4net.Core.LoggingEvent loggingEvent)

--- a/src/redis4net/Layout/LogMessageLayout.cs
+++ b/src/redis4net/Layout/LogMessageLayout.cs
@@ -17,8 +17,18 @@ namespace redis4net.Layout
 		private Dictionary<string, string> innerAdditionalFields;
 		private string additionalFields;
 		private readonly PatternLayout patternLayout;
+        private static readonly Dictionary<string, int> levels = new Dictionary<string, int>
+        {
+            {"ALL", 10 },
+            {"DEBUG", 20 },
+            {"INFO", 30 },
+            {"WARN", 40 },
+            {"ERROR", 50 },
+            {"FATAL", 60 },
+            {"OFF", 0 }
+        };
 
-		public LogMessageLayout()
+        public LogMessageLayout()
 		{
 			IncludeLocationInformation = false;
 			LogStackTraceFromMessage = true;
@@ -211,17 +221,7 @@ namespace redis4net.Layout
 		}
 
 		private static int GetLevelAsNumber(Level level)
-		{
-			var levels = new Dictionary<string, int>
-			{
-				{"ALL", 10 },
-				{"DEBUG", 20 },
-				{"INFO", 30 },
-				{"WARN", 40 },
-				{"ERROR", 50 },
-				{"FATAL", 60 },
-				{"OFF", 0 }
-			};
+		{			
 			return levels.ContainsKey(level.Name) ? levels[level.Name] : 10;
 		}
 

--- a/src/redis4net/Layout/LogMessageLayout.cs
+++ b/src/redis4net/Layout/LogMessageLayout.cs
@@ -134,13 +134,16 @@ namespace redis4net.Layout
 			var message = new LogMessage
 			{
 				Host = Environment.MachineName,
-				SysLogLevel = GetSyslogSeverity(loggingEvent.Level),
-				TimeStamp = loggingEvent.TimeStamp,
-			};
+                Level = GetLevelAsNumber(loggingEvent.Level),
+                LevelName = loggingEvent.Level.Name,
+                Time = loggingEvent.TimeStamp
+                    .ToUniversalTime()
+                    .ToString("yyyy-MM-ddTHH:mm:ss.fffZ")
+            };
 
-			message.Add("LoggerName", loggingEvent.LoggerName);
+            message.Add("loggername", loggingEvent.LoggerName);
 
-			if (this.IncludeLocationInformation)
+            if (this.IncludeLocationInformation)
 			{
 				message.File = loggingEvent.LocationInformation.FileName;
 				message.Line = loggingEvent.LocationInformation.LineNumber;
@@ -207,7 +210,22 @@ namespace redis4net.Layout
 			}
 		}
 
-		private static long GetSyslogSeverity(Level level)
+        private static int GetLevelAsNumber(Level level)
+        {
+            var levels = new Dictionary<string, int>
+            {
+                {"ALL", 10 },
+                {"DEBUG", 20 },
+                {"INFO", 30 },
+                {"WARN", 40 },
+                {"ERROR", 50 },
+                {"FATAL", 60 },
+                {"OFF", 0 }
+            };
+            return levels.ContainsKey(level.Name) ? levels[level.Name] : 10;
+        }
+
+        private static long GetSyslogSeverity(Level level)
 		{
 			if (level == log4net.Core.Level.Alert)
 				return (long)LocalSyslogAppender.SyslogSeverity.Alert;

--- a/src/redis4net/Layout/LogMessageLayout.cs
+++ b/src/redis4net/Layout/LogMessageLayout.cs
@@ -134,16 +134,16 @@ namespace redis4net.Layout
 			var message = new LogMessage
 			{
 				Host = Environment.MachineName,
-                Level = GetLevelAsNumber(loggingEvent.Level),
-                LevelName = loggingEvent.Level.Name,
-                Time = loggingEvent.TimeStamp
-                    .ToUniversalTime()
-                    .ToString("yyyy-MM-ddTHH:mm:ss.fffZ")
-            };
+				Level = GetLevelAsNumber(loggingEvent.Level),
+				LevelName = loggingEvent.Level.Name,
+				Time = loggingEvent.TimeStamp
+					.ToUniversalTime()
+					.ToString("yyyy-MM-ddTHH:mm:ss.fffZ")
+			};
 
-            message.Add("loggername", loggingEvent.LoggerName);
+			message.Add("loggername", loggingEvent.LoggerName);
 
-            if (this.IncludeLocationInformation)
+			if (this.IncludeLocationInformation)
 			{
 				message.File = loggingEvent.LocationInformation.FileName;
 				message.Line = loggingEvent.LocationInformation.LineNumber;
@@ -210,22 +210,22 @@ namespace redis4net.Layout
 			}
 		}
 
-        private static int GetLevelAsNumber(Level level)
-        {
-            var levels = new Dictionary<string, int>
-            {
-                {"ALL", 10 },
-                {"DEBUG", 20 },
-                {"INFO", 30 },
-                {"WARN", 40 },
-                {"ERROR", 50 },
-                {"FATAL", 60 },
-                {"OFF", 0 }
-            };
-            return levels.ContainsKey(level.Name) ? levels[level.Name] : 10;
-        }
+		private static int GetLevelAsNumber(Level level)
+		{
+			var levels = new Dictionary<string, int>
+			{
+				{"ALL", 10 },
+				{"DEBUG", 20 },
+				{"INFO", 30 },
+				{"WARN", 40 },
+				{"ERROR", 50 },
+				{"FATAL", 60 },
+				{"OFF", 0 }
+			};
+			return levels.ContainsKey(level.Name) ? levels[level.Name] : 10;
+		}
 
-        private static long GetSyslogSeverity(Level level)
+		private static long GetSyslogSeverity(Level level)
 		{
 			if (level == log4net.Core.Level.Alert)
 				return (long)LocalSyslogAppender.SyslogSeverity.Alert;

--- a/src/redis4net/LogMessage.cs
+++ b/src/redis4net/LogMessage.cs
@@ -42,25 +42,43 @@ namespace redis4net
 			}
 		}
 
-		public long SysLogLevel
-		{
-			get
-			{
-				if (!this.ContainsKey("sysloglevel"))
-					return int.MinValue;
+        public int Level
+        {
+            get
+            {
+                if (!this.ContainsKey("level"))
+                    return int.MinValue;
 
-				return (long)this["sysloglevel"];
-			}
-			set
-			{
-				if (!this.ContainsKey("sysloglevel"))
-					this.Add("sysloglevel", value);
-				else
-					this["sysloglevel"] = value;
-			}
-		}
+                return (int)this["level"];
+            }
+            set
+            {
+                if (!this.ContainsKey("level"))
+                    this.Add("level", value);
+                else
+                    this["level"] = value;
+            }
+        }
 
-		public string Host
+        public string LevelName
+        {
+            get
+            {
+                if (!this.ContainsKey("levelname"))
+                    return "INFO";
+
+                return (string)this["levelname"];
+            }
+            set
+            {
+                if (!this.ContainsKey("levelname"))
+                    this.Add("levelname", value);
+                else
+                    this["levelname"] = value;
+            }
+        }
+
+        public string Host
 		{
 			get
 			{
@@ -114,25 +132,22 @@ namespace redis4net
 			}
 		}
 
-		public DateTime TimeStamp
-		{
-			get
-			{
-				if (!this.ContainsKey("timestamp"))
-					return DateTime.MinValue;
+        public string Time
+        {
+            get
+            {
+                if (!this.ContainsKey("time"))
+                    return DateTime.MinValue.ToShortDateString();
 
-				var val = this["timestamp"];
-				double value;
-				var parsed = double.TryParse(val as string, NumberStyles.Any, CultureInfo.InvariantCulture, out value);
-				return parsed ? value.FromUnixTimestamp() : DateTime.MinValue;
-			}
-			set
-			{
-				if (!this.ContainsKey("timestamp"))
-					this.Add("timestamp", value.ToUnixTimestamp().ToString(CultureInfo.InvariantCulture));
-				else
-					this["timestamp"] = value.ToUnixTimestamp().ToString(CultureInfo.InvariantCulture);
-			}
-		}
-	}
+                return (string)this["time"]; ;
+            }
+            set
+            {
+                if (!this.ContainsKey("time"))
+                    this.Add("time", value);
+                else
+                    this["time"] = value;
+            }
+        }
+    }
 }

--- a/src/redis4net/LogMessage.cs
+++ b/src/redis4net/LogMessage.cs
@@ -42,43 +42,43 @@ namespace redis4net
 			}
 		}
 
-        public int Level
-        {
-            get
-            {
-                if (!this.ContainsKey("level"))
-                    return int.MinValue;
+		public int Level
+		{
+			get
+			{
+				if (!this.ContainsKey("level"))
+					return int.MinValue;
 
-                return (int)this["level"];
-            }
-            set
-            {
-                if (!this.ContainsKey("level"))
-                    this.Add("level", value);
-                else
-                    this["level"] = value;
-            }
-        }
+				return (int)this["level"];
+			}
+			set
+			{
+				if (!this.ContainsKey("level"))
+					this.Add("level", value);
+				else
+					this["level"] = value;
+			}
+		}
 
-        public string LevelName
-        {
-            get
-            {
-                if (!this.ContainsKey("levelname"))
-                    return "INFO";
+		public string LevelName
+		{
+			get
+			{
+				if (!this.ContainsKey("levelname"))
+					return "INFO";
 
-                return (string)this["levelname"];
-            }
-            set
-            {
-                if (!this.ContainsKey("levelname"))
-                    this.Add("levelname", value);
-                else
-                    this["levelname"] = value;
-            }
-        }
+				return (string)this["levelname"];
+			}
+			set
+			{
+				if (!this.ContainsKey("levelname"))
+					this.Add("levelname", value);
+				else
+					this["levelname"] = value;
+			}
+		}
 
-        public string Host
+		public string Host
 		{
 			get
 			{
@@ -132,22 +132,22 @@ namespace redis4net
 			}
 		}
 
-        public string Time
-        {
-            get
-            {
-                if (!this.ContainsKey("time"))
-                    return DateTime.MinValue.ToShortDateString();
+		public string Time
+		{
+			get
+			{
+				if (!this.ContainsKey("time"))
+					return DateTime.MinValue.ToShortDateString();
 
-                return (string)this["time"]; ;
-            }
-            set
-            {
-                if (!this.ContainsKey("time"))
-                    this.Add("time", value);
-                else
-                    this["time"] = value;
-            }
-        }
-    }
+				return (string)this["time"];
+			}
+			set
+			{
+				if (!this.ContainsKey("time"))
+					this.Add("time", value);
+				else
+					this["time"] = value;
+			}
+		}
+	}
 }

--- a/src/redis4net/Redis/Connection.cs
+++ b/src/redis4net/Redis/Connection.cs
@@ -12,16 +12,16 @@ namespace redis4net.Redis
 
 		public void Open(string hostname, int port, string password, bool enableSSL, string listName)
 		{
-            _listName = listName;
-            var redisConfigOptions = new ConfigurationOptions
-            {
-                Ssl = enableSSL,
-                Password = password,
-                EndPoints = {
-                    { hostname + ":" + port }
-                }
-            };
-            redis = ConnectionMultiplexer.Connect(redisConfigOptions);
+			_listName = listName;
+			var redisConfigOptions = new ConfigurationOptions
+			{
+				Ssl = enableSSL,
+				Password = password,
+				EndPoints = {
+					{ hostname + ":" + port }
+				}
+			};
+			redis = ConnectionMultiplexer.Connect(redisConfigOptions);
 		}
 
 		public bool IsOpen()

--- a/src/redis4net/Redis/Connection.cs
+++ b/src/redis4net/Redis/Connection.cs
@@ -10,17 +10,18 @@ namespace redis4net.Redis
 		private string _listName;
 		private ConnectionMultiplexer redis;
 
-		public void Open(string hostname, int port, string listName)
+		public void Open(string hostname, int port, string password, bool enableSSL, string listName)
 		{
-			try
-			{
-				_listName = listName;
-				redis = ConnectionMultiplexer.Connect(string.Format("{0}:{1}", hostname, port));
-			}
-			catch
-			{
-				redis = null;
-			}
+            _listName = listName;
+            var redisConfigOptions = new ConfigurationOptions
+            {
+                Ssl = enableSSL,
+                Password = password,
+                EndPoints = {
+                    { hostname + ":" + port }
+                }
+            };
+            redis = ConnectionMultiplexer.Connect(redisConfigOptions);
 		}
 
 		public bool IsOpen()

--- a/src/redis4net/Redis/IConnection.cs
+++ b/src/redis4net/Redis/IConnection.cs
@@ -4,7 +4,7 @@ namespace redis4net.Redis
 {
 	public interface IConnection
 	{
-		void Open(string hostname, int port, string listName);
+		void Open(string hostname, int port, string password, bool enableSSL, string listName);
 		bool IsOpen();
 		Task<long> AddToList(string content);
 	}

--- a/src/redis4net/Redis/IConnectionFactory.cs
+++ b/src/redis4net/Redis/IConnectionFactory.cs
@@ -9,9 +9,9 @@ namespace redis4net.Redis
 		private static readonly object Lock = new object();
 
 		private readonly string _hostname;
-        private readonly string _password;
-        private readonly int _portNumber;
-        private readonly bool _enableSSL;
+		private readonly string _password;
+		private readonly int _portNumber;
+		private readonly bool _enableSSL;
 		private readonly int _failedConnectionRetryTimeoutInSeconds;
 		private readonly string _listName;
 		private readonly IConnection _connection;
@@ -22,8 +22,8 @@ namespace redis4net.Redis
 
 			_hostname = hostName;
 			_portNumber = portNumber;
-            _password = password;
-            _enableSSL = enableSSL;
+			_password = password;
+			_enableSSL = enableSSL;
 			_failedConnectionRetryTimeoutInSeconds = failedConnectionRetryTimeoutInSeconds;
 			_listName = listName;
 		}

--- a/src/redis4net/Redis/IConnectionFactory.cs
+++ b/src/redis4net/Redis/IConnectionFactory.cs
@@ -9,17 +9,21 @@ namespace redis4net.Redis
 		private static readonly object Lock = new object();
 
 		private readonly string _hostname;
-		private readonly int _portNumber;
+        private readonly string _password;
+        private readonly int _portNumber;
+        private readonly bool _enableSSL;
 		private readonly int _failedConnectionRetryTimeoutInSeconds;
 		private readonly string _listName;
 		private readonly IConnection _connection;
 
-		public ConnectionFactory(IConnection connection, string hostName, int portNumber, int failedConnectionRetryTimeoutInSeconds, string listName)
+		public ConnectionFactory(IConnection connection, string hostName, int portNumber, string password, bool enableSSL, int failedConnectionRetryTimeoutInSeconds, string listName)
 		{
 			_connection = connection;
 
 			_hostname = hostName;
 			_portNumber = portNumber;
+            _password = password;
+            _enableSSL = enableSSL;
 			_failedConnectionRetryTimeoutInSeconds = failedConnectionRetryTimeoutInSeconds;
 			_listName = listName;
 		}
@@ -60,7 +64,7 @@ namespace redis4net.Redis
 		{
 			if (!_connection.IsOpen())
 			{
-				_connection.Open(_hostname, _portNumber, _listName);
+				_connection.Open(_hostname, _portNumber, _password, _enableSSL, _listName);
 			}
 		}
 	}

--- a/src/redis4net/packages.config
+++ b/src/redis4net/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="log4net" version="2.0.3" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net452" />
-  <package id="StackExchange.Redis" version="1.0.414" targetFramework="net452" />
+  <package id="log4net" version="2.0.7" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
+  <package id="StackExchange.Redis" version="1.2.0" targetFramework="net452" />
 </packages>

--- a/src/redis4net/redis4net.csproj
+++ b/src/redis4net/redis4net.csproj
@@ -35,20 +35,21 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
+    <Reference Include="log4net, Version=2.0.7.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\packages\log4net.2.0.7\lib\net45-full\log4net.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="StackExchange.Redis, Version=1.0.316.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\StackExchange.Redis.1.0.414\lib\net45\StackExchange.Redis.dll</HintPath>
+    <Reference Include="StackExchange.Redis, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\StackExchange.Redis.1.2.0\lib\net45\StackExchange.Redis.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Xml.Linq" />

--- a/src/redis4net/redis4net.nuspec
+++ b/src/redis4net/redis4net.nuspec
@@ -9,7 +9,7 @@
     <licenseUrl>https://github.com/govin/redis4net</licenseUrl>
     <projectUrl>https://github.com/govin/redis4net</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>$description$</description>
+    <description>Internal variant of redis4net, which is a log4net appender that formats logs and adds them to redis lists. This is useful when you have another system like logstash which indexes yours logs. The redis lists that you write to can feed into the logstash indexer.</description>
     <releaseNotes>Adapts to internal logstash setup</releaseNotes>
     <copyright>Copyright 2017</copyright>
     <tags>log4net redis logAppender</tags>

--- a/src/redis4net/redis4net.nuspec
+++ b/src/redis4net/redis4net.nuspec
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>$id$</id>
+    <version>$version$</version>
+    <title>$title$</title>
+    <authors>$author$</authors>
+    <owners>$author$</owners>
+    <licenseUrl>https://github.com/govin/redis4net</licenseUrl>
+    <projectUrl>https://github.com/govin/redis4net</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>$description$</description>
+    <releaseNotes>Adapts to internal logstash setup</releaseNotes>
+    <copyright>Copyright 2017</copyright>
+    <tags>log4net redis logAppender</tags>
+    <dependencies>
+        <dependency id="Newtonsoft.Json" version="9.0.1" />
+        <dependency id="log4net" version="2.0.7" />
+        <dependency id="StackExchange.Redis" version="1.2.0" />
+    </dependencies>
+  </metadata>
+</package>

--- a/src/redis4netTests/Layout/LogMessageLayoutTests.cs
+++ b/src/redis4netTests/Layout/LogMessageLayoutTests.cs
@@ -87,8 +87,9 @@ namespace redis4netTests.Layout
 
 			Assert.AreEqual(result.Message, message);
 			Assert.AreEqual(result.Host, Environment.MachineName);
-			Assert.AreEqual(result.SysLogLevel, (int)LocalSyslogAppender.SyslogSeverity.Debug);
-			Assert.IsTrue(result.TimeStamp >= DateTime.Now.AddMinutes(-1));
+			Assert.AreEqual(result.Level, 30);
+            Assert.AreEqual(result.LevelName, "DEBUG");
+            Assert.IsNotEmpty(result.Time);
 		}
 
 		[Test]

--- a/src/redis4netTests/Layout/LogMessageLayoutTests.cs
+++ b/src/redis4netTests/Layout/LogMessageLayoutTests.cs
@@ -1,9 +1,4 @@
-﻿using log4net;
-using log4net.Appender;
-using log4net.Core;
-using log4net.Repository;
-using log4net.Util;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
@@ -13,10 +8,15 @@ using System.IO;
 
 namespace redis4netTests.Layout
 {
-	using redis4net;
-	using redis4net.Layout;
+    using log4net;
+    using log4net.Appender;
+    using log4net.Core;
+    using log4net.Repository;
+    using log4net.Util;
+    using redis4net;
+    using redis4net.Layout;
 
-	[TestFixture]
+    [TestFixture]
 	public class LogMessageLayoutTests
 	{
 		[Test]
@@ -216,8 +216,8 @@ namespace redis4netTests.Layout
 			var result = GetMessage(layout, loggingEvent);
 
 			Assert.AreEqual(message, result.Message);
-			Assert.IsNotNullOrEmpty(result.Line);
-			Assert.IsNotNullOrEmpty(result.File);
+			Assert.IsNotEmpty(result.Line);
+			Assert.IsNotEmpty(result.File);
 		}
 
 		private LogMessage GetMessage(LogMessageLayout layout, LoggingEvent message)

--- a/src/redis4netTests/packages.config
+++ b/src/redis4netTests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="log4net" version="2.0.3" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net452" />
-  <package id="NUnit" version="2.6.4" targetFramework="net452" />
-  <package id="StackExchange.Redis" version="1.0.414" targetFramework="net452" />
+  <package id="log4net" version="2.0.7" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
+  <package id="NUnit" version="3.6.0" targetFramework="net452" />
+  <package id="StackExchange.Redis" version="1.2.0" targetFramework="net452" />
 </packages>

--- a/src/redis4netTests/redis4net-tests.csproj
+++ b/src/redis4netTests/redis4net-tests.csproj
@@ -34,23 +34,24 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
+    <Reference Include="log4net, Version=2.0.7.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\packages\log4net.2.0.7\lib\net45-full\log4net.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.6.0\lib\net45\nunit.framework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="StackExchange.Redis, Version=1.0.316.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\StackExchange.Redis.1.0.414\lib\net45\StackExchange.Redis.dll</HintPath>
+    <Reference Include="StackExchange.Redis, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\StackExchange.Redis.1.2.0\lib\net45\StackExchange.Redis.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This PR 
- Adapt the redis4net (log4net appender) to our logstash setup - it first queues up log messages in redis before it gets picked up by logstash.

- nuget package available via gemfury